### PR TITLE
Placement group capture child tasks

### DIFF
--- a/lightgbm_ray/main.py
+++ b/lightgbm_ray/main.py
@@ -500,6 +500,7 @@ def _create_actor(
         num_cpus=num_cpus_per_actor,
         num_gpus=num_gpus_per_actor,
         resources=resources_per_actor,
+        placement_group_capture_child_tasks=True,
         placement_group=placement_group or DEFAULT_PG).remote(
             rank=rank,
             num_actors=num_actors,


### PR DESCRIPTION
With the merge of https://github.com/ray-project/ray/pull/17527, the default behavior for capturing child tasks in placement groups has changed. By explicitly setting `placement_group_capture_child_tasks=True` in lightgbm-ray, we ensure that the previous behavior is maintained.