### PR TITLE
Fix flaky CI tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
 
   test_linux_ray_master:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9, 3.7, 3.8]
@@ -68,7 +68,7 @@ jobs:
 
   test_linux_ray_release:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9, 3.7, 3.8]
@@ -101,7 +101,7 @@ jobs:
     # Test compatibility when some optional libraries are missing
     # Test runs on latest ray release
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9, 3.7, 3.8]
@@ -138,7 +138,7 @@ jobs:
   test_linux_cutting_edge:
     # Tests on cutting edge, i.e. latest Ray master, latest LightGBM master
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: [3.6.9, 3.7, 3.8]

--- a/lightgbm_ray/tests/test_end_to_end.py
+++ b/lightgbm_ray/tests/test_end_to_end.py
@@ -140,7 +140,7 @@ class LGBMRayEndToEndTest(unittest.TestCase):
         self.assertSequenceEqual(test_y_second, list(pred_test))
 
     def _testJointTraining(self, cpus_per_actor):
-        ray.init(num_cpus=4, num_gpus=0)
+        ray.init(num_cpus=4, num_gpus=0, include_dashboard=False)
 
         bst = train(
             self.params,
@@ -179,7 +179,7 @@ class LGBMRayEndToEndTest(unittest.TestCase):
         return self._testJointTraining(cpus_per_actor=0)
 
     def testCpusPerActorEqualTo1RaisesException(self):
-        ray.init(num_cpus=4, num_gpus=0)
+        ray.init(num_cpus=4, num_gpus=0, include_dashboard=False)
         with self.assertRaisesRegex(ValueError,
                                     "cpus_per_actor is set to less than 2"):
             train(
@@ -189,7 +189,7 @@ class LGBMRayEndToEndTest(unittest.TestCase):
                 ray_params=RayParams(num_actors=2, cpus_per_actor=1))
 
     def testBothEvalsAndValidSetsRaisesException(self):
-        ray.init(num_cpus=4, num_gpus=0)
+        ray.init(num_cpus=4, num_gpus=0, include_dashboard=False)
         with self.assertRaisesRegex(
                 ValueError,
                 "Specifying both `evals` and `valid_sets` is ambiguous"):
@@ -205,7 +205,7 @@ class LGBMRayEndToEndTest(unittest.TestCase):
     def testTrainPredict(self, init=True, remote=None, **ray_param_dict):
         """Train with evaluation and predict"""
         if init:
-            ray.init(num_cpus=2, num_gpus=0)
+            ray.init(num_cpus=8, num_gpus=0, include_dashboard=False)
 
         dtrain = RayDMatrix(self.x, self.y, sharding=RayShardingMode.BATCH)
 
@@ -270,7 +270,8 @@ class LGBMRayEndToEndTest(unittest.TestCase):
             self.skipTest("Ray client mocks do not work in Ray <= 1.2.0")
         from ray.util.client.ray_client_helpers import ray_start_client_server
 
-        ray.init(num_cpus=2, num_gpus=0)
+        # (yard1) this hangs when num_cpus=2
+        ray.init(num_cpus=8, num_gpus=0, include_dashboard=False)
         self.assertFalse(ray.util.client.ray.is_connected())
         with ray_start_client_server():
             self.assertTrue(ray.util.client.ray.is_connected())
@@ -314,7 +315,7 @@ class LGBMRayEndToEndTest(unittest.TestCase):
             self.skipTest("Ray client mocks do not work in Ray <= 1.2.0")
         from ray.util.client.ray_client_helpers import ray_start_client_server
 
-        ray.init(num_cpus=8, num_gpus=0)
+        ray.init(num_cpus=8, num_gpus=0, include_dashboard=False)
         self.assertFalse(ray.util.client.ray.is_connected())
         with ray_start_client_server():
             self.assertTrue(ray.util.client.ray.is_connected())


### PR DESCRIPTION
Disabling the dashboard seems to stop the client end-to-end tests from failing randomly.