### PR TITLE
Mitigate finishing too quickly

### DIFF
--- a/lightgbm_ray/main.py
+++ b/lightgbm_ray/main.py
@@ -777,11 +777,12 @@ def _train(params: Dict,
     start_wait = time.time()
     last_status = start_wait
 
-    # When the number of trees/dataset size is very small, LightGBM can be too fast,
-    # finishing before the queue Actor gets to process the calls it recieved.
-    # This is a very rare edge case. In order to mitigate,
-    # if the queue has not been handled before, wait simply wait a moment
-    # before checking it one last time.
+    # When the number of trees/dataset size is very small,
+    # training can be too fast and finish before the queue Actor
+    # gets to process the calls it has recieved. This is a very rare edge
+    # case, but it can show up in CI.
+    # In order to mitigate, if the queue has not been handled before,
+    # we simply wait a moment before checking it one last time.
     has_queue_been_handled = False
     try:
         not_ready = training_futures

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -41,7 +41,7 @@ class LightGBMRayTuneTest(unittest.TestCase):
                 "tree_learner": "data",
                 "metrics": ["multi_logloss", "multi_error"]
             },
-            "num_boost_round": tune.grid_search([1, 3])
+            "num_boost_round": tune.choice([1, 3])
         }
 
         def train_func(ray_params, callbacks=None, **kwargs):
@@ -71,6 +71,8 @@ class LightGBMRayTuneTest(unittest.TestCase):
         if init:
             ray.init(num_cpus=8)
         ray_params = RayParams(cpus_per_actor=2, num_actors=2)
+        params = self.params.copy()
+        params["num_boost_round"] = tune.grid_search([1, 3])
         analysis = tune.run(
             self.train_func(ray_params),
             config=self.params,

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -41,7 +41,7 @@ class LightGBMRayTuneTest(unittest.TestCase):
                 "tree_learner": "data",
                 "metrics": ["multi_logloss", "multi_error"]
             },
-            "num_boost_round": tune.choice([1, 3])
+            "num_boost_round": tune.grid_search([1, 3])
         }
 
         def train_func(ray_params, callbacks=None, **kwargs):
@@ -75,7 +75,7 @@ class LightGBMRayTuneTest(unittest.TestCase):
             self.train_func(ray_params),
             config=self.params,
             resources_per_trial=ray_params.get_tune_resources(),
-            num_samples=2)
+            num_samples=1)
 
         self.assertSequenceEqual(
             list(analysis.results_df["training_iteration"]),


### PR DESCRIPTION
If the number of trees and/or the dataset is very small, it is possible for the training to finish before the QueueActor even registers the items put into it, which means that the main loop will exit beforehand. This is a rare edge case, but it shows up in our CI. This is mitigated by waiting a second before getting the results from queue one last time if non have been during the course of the entire training loop.

This PR also deflakes CI by making the tests inside `test_tune` deterministic (they were stochastic before).