### PR TITLE
Update Ray core APIs

### DIFF
--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -20,6 +20,13 @@ from lightgbm_ray import RayDMatrix, train, RayParams, RayShardingMode
 from lightgbm_ray.tune import TuneReportCallback,\
     TuneReportCheckpointCallback, _try_add_tune_callback
 
+try:
+    from ray.air import Checkpoint
+except Exception:
+
+    class Checkpoint:
+        pass
+
 
 class LightGBMRayTuneTest(unittest.TestCase):
     def setUp(self):
@@ -145,7 +152,10 @@ class LightGBMRayTuneTest(unittest.TestCase):
             log_to_file=True,
             local_dir=self.experiment_dir)
 
-        self.assertTrue(os.path.exists(analysis.best_checkpoint))
+        if isinstance(analysis.best_checkpoint, Checkpoint):
+            self.assertTrue(analysis.best_checkpoint)
+        else:
+            self.assertTrue(os.path.exists(analysis.best_checkpoint))
 
     @unittest.skipIf(OrigTuneReportCallback is None,
                      "integration.lightgbmnot yet in ray.tune")
@@ -163,7 +173,10 @@ class LightGBMRayTuneTest(unittest.TestCase):
             log_to_file=True,
             local_dir=self.experiment_dir)
 
-        self.assertTrue(os.path.exists(analysis.best_checkpoint))
+        if isinstance(analysis.best_checkpoint, Checkpoint):
+            self.assertTrue(analysis.best_checkpoint)
+        else:
+            self.assertTrue(os.path.exists(analysis.best_checkpoint))
 
 
 if __name__ == "__main__":

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -164,7 +164,8 @@ class LightGBMRayTuneTest(unittest.TestCase):
         ray_params = RayParams(cpus_per_actor=2, num_actors=1)
         analysis = tune.run(
             self.train_func(
-                ray_params, callbacks=[OrigTuneReportCheckpointCallback()]),
+                ray_params,
+                callbacks=[OrigTuneReportCheckpointCallback(frequency=1)]),
             config=self.params,
             resources_per_trial=ray_params.get_tune_resources(),
             num_samples=1,

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,4 @@ setup(
     long_description="A distributed backend for LightGBM built on top of "
     "distributed computing framework Ray.",
     url="https://github.com/ray-project/lightgbm_ray",
-    install_requires=["lightgbm>=3.2.1", "xgboost_ray>=0.1.9"])
+    install_requires=["lightgbm>=3.2.1", "xgboost_ray>=0.1.10"])


### PR DESCRIPTION
`ray.worker.get_resource_ids()` was deprecated, the correct way to get the same information is now `ray.get_runtime_context().get_assigned_resources()` (see https://github.com/ray-project/ray/pull/26907/files)

Similarly, placement group APIs are updated to use `scheduling_strategy`

See https://github.com/ray-project/xgboost_ray/pull/228