### PR TITLE
Switch to use packaging Version from distutils LooseVersion

### DIFF
--- a/lightgbm_ray/main.py
+++ b/lightgbm_ray/main.py
@@ -31,7 +31,7 @@ from typing import (Tuple, Dict, Any, List, Optional, Type, Union, Sequence,
                     Callable)
 from copy import deepcopy
 from dataclasses import dataclass
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import time
 import logging
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 ELASTIC_RESTART_DISABLED = True
-LIGHTGBM_VERSION = LooseVersion(lightgbm.__version__)
+LIGHTGBM_VERSION = Version(lightgbm.__version__)
 
 
 class StopException(Exception):
@@ -377,7 +377,7 @@ class RayLightGBMActor(RayXGBoostActor):
                 callback.is_rank_0 = return_bst
         kwargs["callbacks"] = callbacks
 
-        if LIGHTGBM_VERSION < LooseVersion("3.3.0"):
+        if LIGHTGBM_VERSION < Version("3.3.0"):
             # In lightgbm<3.3.0, verbosity doesn't always work as a parameter
             # but passing it as kwarg to fit does
             local_params = _choose_param_value(

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,6 +10,7 @@ scikit-learn
 modin
 git+https://github.com/ray-project/xgboost_ray.git
 parameterized
+packaging
 
 # workaround for now
 tensorboardX==2.2

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,4 @@ setup(
     long_description="A distributed backend for LightGBM built on top of "
     "distributed computing framework Ray.",
     url="https://github.com/ray-project/lightgbm_ray",
-    install_requires=["lightgbm>=3.2.1", "xgboost_ray>=0.1.10"])
+    install_requires=["lightgbm>=3.2.1", "xgboost_ray>=0.1.10", "packaging"])


### PR DESCRIPTION
## Summary

This PR removes uses of `distutils.version.LooseVersion` in favor of `packaging.version.Version` at the suggestion of the deprecation warning generated when a user makes use of `LooseVersion`. This PR addresses one of the deprecation warnings identified in https://github.com/ray-project/ray/issues/27851; see also https://github.com/ray-project/xgboost_ray/pull/232. `distutils` [will be deprecated in Python 3.10 and 3.11, and removed entirely in 3.12](https://peps.python.org/pep-0632/).

## Changes

- Replaced `distutils.version.Version` with `packaging.version.Version` everywhere
- Added `packaging` as a dependency in `requirements-test.txt` and in `setup.py`

## Tests

I tested this on my local machine with `pytest` and all the tests that weren't skipped passed.