### PR TITLE
Fix master CI

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@ yapf==0.23.0
 petastorm
 pytest
 pyarrow
-ray[tune]
+ray[tune, data]
 scikit-learn
 modin
 git+https://github.com/ray-project/xgboost_ray.git

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,4 +13,5 @@ parameterized
 packaging
 
 # workaround for now
+protobuf<4.0.0
 tensorboardX==2.2


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

Mirrors https://github.com/ray-project/xgboost_ray/pull/242 and fixes kwargs compatibility with `_wrap_evaluation_matrices`