### PR TITLE
Skip modin example for py37

### DIFF
--- a/lightgbm_ray/examples/simple_modin.py
+++ b/lightgbm_ray/examples/simple_modin.py
@@ -2,8 +2,8 @@ import argparse
 
 import numpy as np
 import pandas as pd
-from packaging.version import Version
 import ray
+from packaging.version import Version
 from sklearn.utils import shuffle
 from xgboost_ray.data_sources.modin import MODIN_INSTALLED
 

--- a/lightgbm_ray/examples/simple_modin.py
+++ b/lightgbm_ray/examples/simple_modin.py
@@ -2,6 +2,7 @@ import argparse
 
 import numpy as np
 import pandas as pd
+from packaging.version import Version
 import ray
 from sklearn.utils import shuffle
 from xgboost_ray.data_sources.modin import MODIN_INSTALLED
@@ -15,6 +16,14 @@ def main(cpus_per_actor, num_actors):
             "Modin is not installed or installed in a version that is not "
             "compatible with lightgbm_ray (< 0.9.0)."
         )
+        return
+
+    import modin
+
+    if Version(modin.__version__) < Version("0.16.0") and Version(
+        ray.__version__
+    ) >= Version("2.6.0"):
+        print("modin<=0.16.0 is not compatible with ray>=2.6.0.")
         return
 
     # Import modin after initializing Ray


### PR DESCRIPTION
* `modin==0.12.1` is the latest version for py37
* Nightly ray (which will become Ray 2.6) no longer supports `modin<0.16.0` due to removing a core API that modin depended on. See here for context: https://github.com/ray-project/ray/pull/30895#issuecomment-1581688947
* So, Ray 2.6 will no longer support modin for py37. Thus, we should skip the modin test on py37 in the CI here.