### PR TITLE
Use new train.report API

### DIFF
--- a/lightgbm_ray/examples/simple_tune.py
+++ b/lightgbm_ray/examples/simple_tune.py
@@ -70,7 +70,7 @@ def main(cpus_per_actor, num_actors, num_samples):
 
     # Load the best model checkpoint.
     best_bst = lightgbm_ray.tune.load_model(
-        os.path.join(analysis.best_logdir, "tuned.lgbm")
+        os.path.join(analysis.best_trial.local_path, "tuned.lgbm")
     )
 
     best_bst.save_model("best_model.lgbm")

--- a/lightgbm_ray/main.py
+++ b/lightgbm_ray/main.py
@@ -253,7 +253,7 @@ class RayLightGBMActor(RayXGBoostActor):
             def _callback(env: CallbackEnv) -> None:
                 if not is_rank_0:
                     return
-                if (
+                if this.checkpoint_frequency > 0 and (
                     env.iteration == env.end_iteration - 1
                     or env.iteration % this.checkpoint_frequency == 0
                 ):

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -144,8 +144,13 @@ class LightGBMRayTuneTest(unittest.TestCase):
 
         replaced = in_dict["callbacks"][0]
         self.assertTrue(isinstance(replaced, TuneReportCheckpointCallback))
-        self.assertSequenceEqual(replaced._report._metrics, ["met"])
-        self.assertEqual(replaced._checkpoint._filename, "test")
+
+        if getattr(replaced, "_report", None):
+            self.assertSequenceEqual(replaced._report._metrics, ["met"])
+            self.assertEqual(replaced._checkpoint._filename, "test")
+        else:
+            self.assertSequenceEqual(replaced._metrics, ["met"])
+            self.assertEqual(replaced._filename, "test")
 
     def testEndToEndCheckpointing(self):
         ray.init(num_cpus=4)


### PR DESCRIPTION
We are converging on using `train.report` throughout the Ray library code base instead of `tune.report`.

See https://github.com/ray-project/xgboost_ray/pull/292