### PR TITLE
Simplify checkpointing callback for Ray Train/Tune integration

### DIFF
--- a/lightgbm_ray/main.py
+++ b/lightgbm_ray/main.py
@@ -97,7 +97,7 @@ RAY_TUNE_INSTALLED = True
 try:
     import ray.train
     import ray.tune
-except (ImportError, ModuleNotFoundError) as e:
+except (ImportError, ModuleNotFoundError):
     RAY_TUNE_INSTALLED = False
 
 if RAY_TUNE_INSTALLED:

--- a/lightgbm_ray/main.py
+++ b/lightgbm_ray/main.py
@@ -137,6 +137,12 @@ def _check_cpus_per_actor_at_least_2(cpus_per_actor: int, suppress_exception: bo
             )
 
 
+def _in_ray_tune_session() -> bool:
+    return (
+        RAY_TUNE_INSTALLED and ray.train.get_context().get_trial_resources() is not None
+    )
+
+
 def _get_data_dict(data: RayDMatrix, param: Dict) -> Dict:
     if not LEGACY_MATRIX and isinstance(data, RayDeviceQuantileDMatrix):
         # If we only got a single data shard, create a list so we can
@@ -1058,8 +1064,7 @@ def train(
     os.environ.setdefault("RAY_IGNORE_UNHANDLED_ERRORS", "1")
 
     if _remote is None:
-        in_ray_tune_session = RAY_TUNE_INSTALLED and ray.train.get_context()
-        _remote = _is_client_connected() and not in_ray_tune_session
+        _remote = _is_client_connected() and not _in_ray_tune_session()
 
     if not ray.is_initialized():
         ray.init()
@@ -1572,8 +1577,7 @@ def predict(
     os.environ.setdefault("RAY_IGNORE_UNHANDLED_ERRORS", "1")
 
     if _remote is None:
-        in_ray_tune_session = RAY_TUNE_INSTALLED and ray.train.get_context()
-        _remote = _is_client_connected() and not in_ray_tune_session
+        _remote = _is_client_connected() and not _in_ray_tune_session()
 
     if not ray.is_initialized():
         ray.init()

--- a/lightgbm_ray/main.py
+++ b/lightgbm_ray/main.py
@@ -92,6 +92,8 @@ from xgboost_ray.session import put_queue
 
 from lightgbm_ray.util import find_free_port, is_port_free, lgbm_network_free
 
+RAY_TUNE_INSTALLED = True
+
 try:
     import ray.train
     import ray.tune

--- a/lightgbm_ray/main.py
+++ b/lightgbm_ray/main.py
@@ -86,13 +86,23 @@ from xgboost_ray.main import (
     concat_dataframes,
     force_on_current_node,
     get_current_placement_group,
-    is_session_enabled,
     pickle,
 )
 from xgboost_ray.session import put_queue
 
-from lightgbm_ray.tune import _try_add_tune_callback, _TuneLGBMRank0Mixin
 from lightgbm_ray.util import find_free_port, is_port_free, lgbm_network_free
+
+try:
+    import ray.train
+    import ray.tune
+except (ImportError, ModuleNotFoundError) as e:
+    RAY_TUNE_INSTALLED = False
+
+if RAY_TUNE_INSTALLED:
+    from lightgbm_ray.tune import _try_add_tune_callback, _TuneLGBMRank0Mixin
+else:
+    _try_add_tune_callback = _TuneLGBMRank0Mixin = None
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -411,9 +421,10 @@ class RayLightGBMActor(RayXGBoostActor):
         callbacks.append(self._save_checkpoint_callback(is_rank_0=return_bst))
         callbacks.append(self._stop_callback(is_rank_0=return_bst))
         callbacks.append(record_evaluation(evals_result))
-        for callback in callbacks:
-            if isinstance(callback, _TuneLGBMRank0Mixin):
-                callback.is_rank_0 = return_bst
+        if RAY_TUNE_INSTALLED:
+            for callback in callbacks:
+                if isinstance(callback, _TuneLGBMRank0Mixin):
+                    callback.is_rank_0 = return_bst
         kwargs["callbacks"] = callbacks
 
         if LIGHTGBM_VERSION < Version("3.3.0"):
@@ -1045,7 +1056,8 @@ def train(
     os.environ.setdefault("RAY_IGNORE_UNHANDLED_ERRORS", "1")
 
     if _remote is None:
-        _remote = _is_client_connected() and not is_session_enabled()
+        in_ray_tune_session = RAY_TUNE_INSTALLED and ray.train.get_context()
+        _remote = _is_client_connected() and not in_ray_tune_session
 
     if not ray.is_initialized():
         ray.init()
@@ -1153,7 +1165,11 @@ def train(
             "`dtrain = RayDMatrix(data=data, label=label)`.".format(type(dtrain))
         )
 
-    added_tune_callback = _try_add_tune_callback(kwargs)
+    if RAY_TUNE_INSTALLED:
+        added_tune_callback = _try_add_tune_callback(kwargs)
+    else:
+        added_tune_callback = False
+
     # LightGBM currently does not support elastic training.
     if ray_params.elastic_training:
         raise ValueError(
@@ -1270,7 +1286,7 @@ def train(
                 evals.append((valid_data, f"valid_{i}"))
 
     if evals:
-        for (deval, _name) in evals:
+        for deval, _name in evals:
             if not isinstance(deval, RayDMatrix):
                 raise ValueError(
                     "Evaluation data must be a `RayDMatrix`, got " f"{type(deval)}."
@@ -1554,7 +1570,8 @@ def predict(
     os.environ.setdefault("RAY_IGNORE_UNHANDLED_ERRORS", "1")
 
     if _remote is None:
-        _remote = _is_client_connected() and not is_session_enabled()
+        in_ray_tune_session = RAY_TUNE_INSTALLED and ray.train.get_context()
+        _remote = _is_client_connected() and not in_ray_tune_session
 
     if not ray.is_initialized():
         ray.init()

--- a/lightgbm_ray/tests/test_client.py
+++ b/lightgbm_ray/tests/test_client.py
@@ -19,6 +19,14 @@ def start_client_server_5_cpus():
         yield client
 
 
+@pytest.fixture
+def start_client_server_5_cpus_modin(monkeypatch):
+    monkeypatch.setenv("__MODIN_AUTOIMPORT_PANDAS__", "1")
+    ray.init(num_cpus=5, runtime_env={"env_vars": {"__MODIN_AUTOIMPORT_PANDAS__": "1"}})
+    with ray_start_client_server() as client:
+        yield client
+
+
 def test_simple_train(start_client_server_4_cpus):
     assert ray.util.client.ray.is_connected()
     from lightgbm_ray.examples.simple import main
@@ -41,7 +49,7 @@ def test_simple_dask(start_client_server_5_cpus):
     main(cpus_per_actor=2, num_actors=2)
 
 
-def test_simple_modin(start_client_server_5_cpus):
+def test_simple_modin(start_client_server_5_cpus_modin):
     assert ray.util.client.ray.is_connected()
     from lightgbm_ray.examples.simple_modin import main
 

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -7,9 +7,8 @@ from unittest.mock import patch
 import numpy as np
 import ray
 from ray import tune
-
 from ray.tune.integration.lightgbm import (
-    TuneReportCheckpointCallback as OrigTuneReportCheckpointCallback
+    TuneReportCheckpointCallback as OrigTuneReportCheckpointCallback,
 )
 
 from lightgbm_ray import RayDMatrix, RayParams, RayShardingMode, train

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -8,15 +8,9 @@ import numpy as np
 import ray
 from ray import tune
 
-try:
-    from ray.tune.integration.lightgbm import (
-        TuneReportCallback as OrigTuneReportCallback,
-    )
-    from ray.tune.integration.lightgbm import (
-        TuneReportCheckpointCallback as OrigTuneReportCheckpointCallback,
-    )
-except ImportError:
-    OrigTuneReportCallback = OrigTuneReportCheckpointCallback = None
+from ray.tune.integration.lightgbm import (
+    TuneReportCheckpointCallback as OrigTuneReportCheckpointCallback
+)
 
 from lightgbm_ray import RayDMatrix, RayParams, RayShardingMode, train
 from lightgbm_ray.tune import TuneReportCheckpointCallback, _try_add_tune_callback
@@ -105,15 +99,12 @@ class LightGBMRayTuneTest(unittest.TestCase):
             self.assertTrue(ray.util.client.ray.is_connected())
             self.testNumIters(init=False)
 
-    @unittest.skipIf(
-        OrigTuneReportCallback is None, "integration.lightgbmnot yet in ray.tune"
-    )
     def testReplaceTuneCheckpoints(self):
         """Test if ray.tune.integration.lightgbm callbacks are replaced"""
         ray.init(num_cpus=4)
 
         # Report and checkpointing callback
-        in_cp = [OrigTuneReportCheckpointCallback(metrics="met", filename="test")]
+        in_cp = [OrigTuneReportCheckpointCallback(metrics="met")]
         in_dict = {"callbacks": in_cp}
 
         with patch("ray.train.get_context") as mocked:
@@ -143,9 +134,6 @@ class LightGBMRayTuneTest(unittest.TestCase):
 
         self.assertTrue(os.path.exists(analysis.best_checkpoint.path))
 
-    @unittest.skipIf(
-        OrigTuneReportCallback is None, "integration.lightgbmnot yet in ray.tune"
-    )
     def testEndToEndCheckpointingOrigTune(self):
         ray.init(num_cpus=4)
         ray_params = RayParams(cpus_per_actor=2, num_actors=1)

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 import ray
@@ -106,7 +106,7 @@ class LightGBMRayTuneTest(unittest.TestCase):
         in_dict = {"callbacks": in_cp}
 
         with patch("ray.train.get_context") as mocked:
-            mocked.return_value = True
+            mocked.return_value = MagicMock(return_value=True)
             _try_add_tune_callback(in_dict)
 
         replaced = in_dict["callbacks"][0]

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import ray

--- a/lightgbm_ray/tests/test_tune.py
+++ b/lightgbm_ray/tests/test_tune.py
@@ -42,7 +42,7 @@ class LightGBMRayTuneTest(unittest.TestCase):
             "num_boost_round": tune.choice([1, 3]),
         }
 
-        def train_func(ray_params, callbacks=None, **kwargs):
+        def train_func(ray_params, callbacks=None):
             def _inner_train(config):
                 train_set = RayDMatrix(x, y, sharding=RayShardingMode.BATCH)
                 train(
@@ -52,7 +52,6 @@ class LightGBMRayTuneTest(unittest.TestCase):
                     num_boost_round=config["num_boost_round"],
                     evals=[(train_set, "train")],
                     callbacks=callbacks,
-                    **kwargs
                 )
 
             return _inner_train

--- a/lightgbm_ray/tune.py
+++ b/lightgbm_ray/tune.py
@@ -1,13 +1,12 @@
 import logging
 from typing import Dict
 
+import ray
 from lightgbm.basic import Booster
 from lightgbm.callback import CallbackEnv
+from ray.util.annotations import PublicAPI
 from xgboost_ray.session import put_queue
 from xgboost_ray.util import force_on_current_node
-
-import ray
-from ray.util.annotations import PublicAPI
 
 try:
     import ray.train
@@ -19,9 +18,7 @@ except (ImportError, ModuleNotFoundError) as e:
     ) from e
 
 
-from ray.tune.integration.lightgbm import (
-    TuneReportCallback as OrigTuneReportCallback,
-)
+from ray.tune.integration.lightgbm import TuneReportCallback as OrigTuneReportCallback
 from ray.tune.integration.lightgbm import (
     TuneReportCheckpointCallback as OrigTuneReportCheckpointCallback,
 )

--- a/lightgbm_ray/tune.py
+++ b/lightgbm_ray/tune.py
@@ -55,7 +55,7 @@ class TuneReportCallback(_TuneLGBMRank0Mixin, OrigTuneReportCallback):
         # TODO(justinvyu): [code_removal] Remove in Ray 2.11.
         raise DeprecationWarning(
             "`TuneReportCallback` is deprecated. "
-            "Use `xgboost_ray.tune.TuneReportCheckpointCallback` instead."
+            "Use `ray.tune.integration.lightgbm.TuneReportCheckpointCallback` instead."
         )
 
 

--- a/lightgbm_ray/tune.py
+++ b/lightgbm_ray/tune.py
@@ -63,7 +63,9 @@ class TuneReportCallback(_TuneLGBMRank0Mixin, OrigTuneReportCallback):
 
 
 def _try_add_tune_callback(kwargs: Dict):
-    ray_train_context_initialized = ray.train.get_context()
+    ray_train_context_initialized = (
+        ray.train.get_context().get_trial_resources() is not None
+    )
     if ray_train_context_initialized:
         callbacks = kwargs.get("callbacks", []) or []
         new_callbacks = []

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -5,7 +5,10 @@ pytest
 pyarrow<15.0.0
 ray[tune, data, default]
 scikit-learn
-modin
+# modin==0.23.1.post0 is not compatible with lightgbm_ray py38
+modin<=0.23.1; python_version == '3.8'
+# modin==0.26.0 is not compatible with lightgbm_ray py39+
+modin<0.26.0; python_version > '3.8'
 git+https://github.com/ray-project/xgboost_ray.git
 
 #workaround for now

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -2,7 +2,7 @@ packaging
 parameterized
 petastorm
 pytest
-pyarrow
+pyarrow<15.0.0
 ray[tune, data, default]
 scikit-learn
 modin


### PR DESCRIPTION
This PR simplifies the Ray Train/Tune integration for `lightgbm_ray` by doing the following:
* Removes the deprecated APIs (`TuneReportCallback`, `is_session_enabled`, `callback._report`, `callback._checkpoint`)
* Unifies the checkpointing integration with Tune around `TuneReportCheckpointCallback`
* Uses the public `ray.train.get_context` API instead of detecting the train "session"

Related PR on the main ray repo: https://github.com/ray-project/ray/pull/42111